### PR TITLE
Update documentation links

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,33 +7,33 @@ series of projects that together form a CMake development ecosystem.
 ## CMaize
 
 - [GitHub](https://github.com/CMakePP/CMaize)
-- [Documentation](https://cmaize.readthedocs.io/en/latest/)
+- [Documentation](https://cmakepp.github.io/CMaize)
 
 The top-level user API for writing a build system using the CMakePP development
 ecosystem. If you are building a project that uses CMaize as its build system
 or you are interested in creating a project that uses the CMakePP ecosystem,
 CMaize is the project to consider.
 
-## CMakePPCore
+## CMakePPLang
 
-- [GitHub](https://github.com/CMakePP/CMakePPCore)
-- [Documentation](https://cmakeppcore.readthedocs.io/en/latest/)
+- [GitHub](https://github.com/CMakePP/CMakePPLang)
+- [Documentation](https://cmakepp.github.io/CMakePPLang)
 
 Maybe you don't care for the CMaize user-APIs or you want to design your own.
 We highly recommend using the object-oriented CMakePP language for such
-endeavors. CMakePPCore implements the CMakePP language.
+endeavors. CMakePPLang implements the CMakePP language.
 
 ## CMakeTest
 
 - [GitHub](https://github.com/CMakePP/CMakeTest)
-- [Documentation](https://cmaketest.readthedocs.io/en/latest/)
+- [Documentation](https://cmakepp.github.io/CMakeTest)
 
 A unit-testing framework for code written using CMake/CMakePP languages.
 
 ## CMinx
 
 - [GitHub](https://github.com/CMakePP/CMinx)
-- [Documentation](https://cmakedoc.readthedocs.io/en/latest/)
+- [Documentation](https://cmakepp.github.io/CMinx)
 
 A tool, a la Doxygen, for generating reStructuredText documentation for APIs of
 CMake/CMakePP functions.
@@ -41,7 +41,7 @@ CMake/CMakePP functions.
 ## CMakeDev
 
 - [GitHub](https://github.com/CMakePP/CMakeDev)
-- [Documentation](https://cmakedev.readthedocs.io/en/latest/)
+- [Documentation](https://cmakepp.github.io/CMakeDev)
 
 Developers manual for the CMakePP project. A useful community resource for
 others wanting to write their own CMake modules.


### PR DESCRIPTION
Update documentation links to point to GitHub Pages instead of Read the Docs. This will also fix #2, since the CMaize link will be valid after CMaize PR #[64](https://github.com/CMakePP/CMaize/pull/64) is merged and the docs are hosted.